### PR TITLE
Rounding changes for denorm numbers

### DIFF
--- a/src/Utils/CustomFloatTypes.cs
+++ b/src/Utils/CustomFloatTypes.cs
@@ -48,15 +48,24 @@ public struct HalfFloat
         int myExponent = exponent + ExponentBias;
 
         // Round the mantissa
-        uint roundingBit = 1 << (SingleNumMantissaBits - NumMantissaBits - 1);
-        if ((mantissaBits & roundingBit) != 0)
+        if (myExponent == -NumMantissaBits)
         {
-            mantissaBits += roundingBit;
-            if ((mantissaBits & ~SingleMantissaMask) != 0)
+            // Denormal edge case: rounding epsilon/2 <= x < epsilon always rounds to epsilon
+            mantissaBits = 0;
+            myExponent += 1;
+        }
+        else if (myExponent > -NumMantissaBits)
+        {
+            uint roundingBit = 1u << (SingleNumMantissaBits - NumMantissaBits - 1 + Math.Max(0, 1 - myExponent));
+            if ((mantissaBits & roundingBit) != 0)
             {
-                // Rounding overflowed mantissa, increment exponent
-                mantissaBits = 0;
-                myExponent += 1;
+                mantissaBits += roundingBit;
+                if ((mantissaBits & ~SingleMantissaMask) != 0)
+                {
+                    // Rounding overflowed mantissa, increment exponent
+                    mantissaBits = 0;
+                    myExponent += 1;
+                }
             }
         }
 
@@ -241,15 +250,24 @@ public struct QuarterFloat
         int myExponent = exponent + ExponentBias;
 
         // Round the mantissa
-        uint roundingBit = 1 << (SingleNumMantissaBits - NumMantissaBits - 1);
-        if ((mantissaBits & roundingBit) != 0)
+        if (myExponent == -NumMantissaBits)
         {
-            mantissaBits += roundingBit;
-            if ((mantissaBits & ~SingleMantissaMask) != 0)
+            // Denormal edge case: rounding epsilon/2 <= x < epsilon always rounds to epsilon
+            mantissaBits = 0;
+            myExponent += 1;
+        }
+        else if (myExponent > -NumMantissaBits)
+        {
+            uint roundingBit = 1u << (SingleNumMantissaBits - NumMantissaBits - 1 + Math.Max(0, 1 - myExponent));
+            if ((mantissaBits & roundingBit) != 0)
             {
-                // Rounding overflowed mantissa, increment exponent
-                mantissaBits = 0;
-                myExponent += 1;
+                mantissaBits += roundingBit;
+                if ((mantissaBits & ~SingleMantissaMask) != 0)
+                {
+                    // Rounding overflowed mantissa, increment exponent
+                    mantissaBits = 0;
+                    myExponent += 1;
+                }
             }
         }
 


### PR DESCRIPTION
I couldn't leave well enough alone :)

This allows the rounding behaviour in HalfFloat/QuarterFloat to work when the numbers are subnormal (i.e. at the very lowest end of representable numbers)

It doesn't really change much in practice but it makes me feel more secure knowing it's done right lol

If you're interested I could also have a go at adding unit tests to the project (truth be told i've done that in another branch, though i'd have to rip out other changes for it)