### PR TITLE
Record the kiln as a separate route

### DIFF
--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -171,7 +171,6 @@ namespace FollowMePeak
             if (scene.name.StartsWith("Level_"))
             {
                 StartCoroutine(InitializePathSystem(scene));
-                _recordingManager.StartRecording();
             }
             else
             {
@@ -261,11 +260,15 @@ namespace FollowMePeak
             }
         }
 
-        public void OnClimbSegmentComplete(string biomeName)
+        public void OnClimbSegmentComplete()
         {
-            Logger.LogInfo($"Climb segment in {_climbDataService.CurrentLevelID} {biomeName} complete; saving.");
-            _recordingManager.SaveCurrentClimb(biomeName);
-            _recordingManager.StartRecording();
+            _recordingManager.SaveCurrentClimb();
+        }
+
+        public void OnNextClimbSegment(string nextBiomeName)
+        {
+            OnClimbSegmentComplete();
+            _recordingManager.StartRecording(nextBiomeName);
         }
         
         // Method to show tag selection for newly created climbs - DISABLED FOR NOW

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -261,8 +261,9 @@ namespace FollowMePeak
             }
         }
 
-        public void OnCampfireLit(string biomeName)
+        public void OnClimbSegmentComplete(string biomeName)
         {
+            Logger.LogInfo($"Climb segment in {_climbDataService.CurrentLevelID} {biomeName} complete; saving.");
             _recordingManager.SaveCurrentClimb(biomeName);
             _recordingManager.StartRecording();
         }

--- a/src/Services/Patches/PluginPatches.cs
+++ b/src/Services/Patches/PluginPatches.cs
@@ -27,8 +27,17 @@ namespace FollowMePeak.Patches
         {
             if(Plugin.Instance != null)
             {
-                Debug.Log("[FollowMe-Peak] Campfire.Light_Rpc() completed. Saving triggered.");
-                Plugin.Instance.OnCampfireLit(BiomeNameOfCompletedSegment);
+                Plugin.Instance.OnClimbSegmentComplete(BiomeNameOfCompletedSegment);
+            }
+        }
+
+        [HarmonyPatch(typeof(PeakHandler), nameof(PeakHandler.SummonHelicopter))]
+        [HarmonyPostfix]
+        public static void SavePathAfterHelicopterSummoned()
+        {
+            if (Plugin.Instance != null)
+            {
+                Plugin.Instance.OnClimbSegmentComplete(BiomeNameOfCompletedSegment);
             }
         }
     }

--- a/src/Services/Patches/PluginPatches.cs
+++ b/src/Services/Patches/PluginPatches.cs
@@ -1,33 +1,16 @@
-using System;
 using HarmonyLib;
-using UnityEngine;
-using Zorro.Core;
 
 namespace FollowMePeak.Patches
 {
     public class PluginPatches
     {
-        public static string BiomeNameOfCompletedSegment { get; set; }
-
-        [HarmonyPatch(typeof(Campfire), "Light_Rpc")]
-        [HarmonyPrefix]
-        public static void CaptureBiomeNameBeforeCompletion()
-        {
-            if (Singleton<MapHandler>.Instance != null)
-            {
-                Segment currentSegmentEnum = Singleton<MapHandler>.Instance.GetCurrentSegment();
-                BiomeNameOfCompletedSegment = Enum.GetName(typeof(Segment), currentSegmentEnum);
-                Debug.Log($"[FollowMe-Peak] Biome captured: {BiomeNameOfCompletedSegment}");
-            }
-        }
-
-        [HarmonyPatch(typeof(Campfire), "Light_Rpc")]
+        [HarmonyPatch(typeof(MountainProgressHandler), nameof(MountainProgressHandler.TriggerReached))]
         [HarmonyPostfix]
-        public static void SavePathAfterCampfireLit()
+        public static void StartNewSegment(MountainProgressHandler.ProgressPoint __0)
         {
             if(Plugin.Instance != null)
             {
-                Plugin.Instance.OnClimbSegmentComplete(BiomeNameOfCompletedSegment);
+                Plugin.Instance.OnNextClimbSegment(__0.title);
             }
         }
 
@@ -37,7 +20,7 @@ namespace FollowMePeak.Patches
         {
             if (Plugin.Instance != null)
             {
-                Plugin.Instance.OnClimbSegmentComplete(BiomeNameOfCompletedSegment);
+                Plugin.Instance.OnClimbSegmentComplete();
             }
         }
     }


### PR DESCRIPTION
And also the peak :)

This approach does get somewhat different biome names:
```sh
score@kirisame ..PEAK/BepInEx/plugins/FollowMePeak_Data % jq '.[].BiomeName' < Level_1_76.json | awk '!u[$0]{print;u[$0]++}'
"Beach|Level_1_76"
"Tropics"
"Tropics|Level_1_76"
"Alpine|Level_1_76"
"Beach"
"Caldera"
"Alpine"
"Caldera|Level_1_76"
"SHORE"
"TROPICS"
"ALPINE"
"CALDERA"
"THE KILN"
"PEAK"
```

As you can see, after the change, they're capitalised. If that's a problem it can be fixed quite easily, though I think it's harmless.

What this PR actually ends up changing:

- Biome name is recorded on entry, not exit
- Biome names are capitalised because they come from a different part of the game code
- A new route is started every time a new "segment" happens, which isn't always a campfire (e.g. crossing over from kiln into peak)
- Speaking of which, kiln and peak are recorded now (fixes #1)
- Shore (beach) doesn't start recording when you spawn, it starts recording once the biome name pops up on screen. (this is also something that could be worked around if it's undesirable)